### PR TITLE
WIP: Add websearch plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "freedesktop_entry_parser"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +627,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -782,6 +815,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scout_plugin_websearch"
+version = "0.1.0"
+dependencies = [
+ "gdk-pixbuf",
+ "gtk",
+ "opener",
+ "pango",
+ "scout-core",
+ "url",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +964,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +997,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1025,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = [ "core", "app", "plugins/application", "plugins/directory" ]
+members = [ "core", "app", "plugins/application", "plugins/directory", "plugins/websearch" ]

--- a/app/src/window/app.rs
+++ b/app/src/window/app.rs
@@ -36,7 +36,7 @@ pub struct App {
 
 impl App {
 	fn build_interface(application: &gtk::Application, preferences: &Preferences, styles: Vec<&'static str>) -> AppWidgets {
-		
+
 		// Basic window configuration //
 
 		let window = gtk::ApplicationWindow::new(application);
@@ -50,7 +50,7 @@ impl App {
 		window.set_skip_taskbar_hint(preferences.hide_on_unfocus);
 		window.set_skip_pager_hint(preferences.hide_on_unfocus);
 		window.set_keep_above(preferences.always_on_top);
-		
+
 		style::style(&window, &preferences, styles);
 
 		let app_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -95,7 +95,7 @@ impl App {
 			button.get_style_context().add_class("flat");
 			button.get_style_context().add_class("model");
 			button.set_action_name(Some(&action));
-			
+
 			let button_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
 			button.add(&button_box);
 
@@ -230,7 +230,7 @@ impl App {
 		let logout_action = gio::SimpleAction::new("logout", None);
 		logout_action.connect_activate(move |_, _| drop(std::process::Command::new("xfce4-session-logout").spawn()));
 		actions.add_action(&logout_action);
-		
+
 		let shutdown_action = gio::SimpleAction::new("shutdown", None);
 		shutdown_action.connect_activate(move |_, _| drop(system_shutdown::shutdown()));
 		actions.add_action(&shutdown_action);
@@ -251,7 +251,7 @@ impl App {
 				else { app.hide() }
 			}
 		});
-		
+
 		if app_ref.preferences.borrow().hide_on_unfocus {
 			let app_clone = app.clone();
 			app_ref.widgets.window.connect_focus_out_event(move |_, _| {
@@ -263,11 +263,12 @@ impl App {
 
 	pub fn new(application: &gtk::Application) -> Shared<Self> {
 		let preferences = Preferences::new(None);
-		
+
 		let mut plugins = Plugins::new();
 
 		plugins.load("target/debug/libscout_plugin_application.so").expect("Invocation Failed");
 		plugins.load("target/debug/libscout_plugin_directory.so").expect("Invocation Failed");
+		plugins.load("target/debug/libscout_plugin_websearch.so").expect("Invocation Failed");
 		// plugins.load("target/debug/libscout_plugin_starter.so").expect("Invocation Failed");
 
 		let widgets = App::build_interface(&application, &preferences.borrow(), plugins.get_styles());

--- a/plugins/websearch/Cargo.toml
+++ b/plugins/websearch/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition = "2018"
+version = "0.1.0"
+name = "scout_plugin_websearch"
+authors = [ "rubenwardy <rw@rubenwardy.com>" ]
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+scout-core = { path = "../../core" }
+
+opener = "0.4.1"
+url = "2.2.2"
+pango = "0.9.1"
+gdk-pixbuf = "0.9.0"
+gtk = { version = "0.9.0", features = [ "v3_24" ] }

--- a/plugins/websearch/src/lib.rs
+++ b/plugins/websearch/src/lib.rs
@@ -1,0 +1,48 @@
+use scout_core::{ Plugin, SearchResult, PluginRegistrar };
+
+mod result;
+use result::{WebSearchResult, SearchEngine };
+
+pub struct WebSearchPlugin {
+	engines: Vec<SearchEngine>
+}
+
+impl WebSearchPlugin {
+	fn new() -> Box<dyn Plugin> {
+		gtk::init().unwrap();
+
+		let engines = vec![SearchEngine {
+			name: "Google".to_string(),
+			base_url: "https://google.com/search".to_string(),
+			query_argument: "q".to_string(),
+			icon: None
+		}];
+
+		Box::new(WebSearchPlugin { engines })
+	}
+}
+
+impl Plugin for WebSearchPlugin {
+	fn get_results(&self, query: &str) -> scout_core::Result<Vec<(usize, Box<dyn SearchResult>)>> {
+		if query.len() == 0 {
+			return Ok(vec![]);
+		}
+
+		Ok(self.engines.iter()
+			.map(|engine| Box::new(WebSearchResult::new(engine, query)) as Box<dyn SearchResult>)
+			.map(|result| (result.get_ranking(&query), result))
+			.filter(|(score, _)| *score > 0)
+			.collect::<Vec<(usize, Box<dyn SearchResult>)>>())
+	}
+
+	fn get_styles(&self) -> scout_core::Result<&'static str> {
+		Ok(include_str!("../style/.build.css"))
+	}
+}
+
+#[allow(improper_ctypes_definitions)]
+extern "C" fn register(registrar: &mut dyn PluginRegistrar) {
+	registrar.register("websearch", WebSearchPlugin::new());
+}
+
+scout_core::export_plugin!(register);

--- a/plugins/websearch/src/result.rs
+++ b/plugins/websearch/src/result.rs
@@ -1,0 +1,117 @@
+use gtk::prelude::*;
+use scout_core::SearchResult;
+use url::{ Url };
+
+
+#[derive(Clone)]
+pub struct SearchEngine {
+	pub(crate) name: String,
+	pub(crate) base_url: String,
+	pub(crate) query_argument: String,
+	pub(crate) icon: Option<String>,
+}
+
+
+/**
+ * A web search engine result, created from a search engine.
+ * Opens up the search engine in the web browser when activated.
+ */
+
+#[derive(Clone)]
+pub struct WebSearchResult {
+	engine: SearchEngine,
+	query: String,
+	widget: gtk::Box,
+	top_button: gtk::Button
+}
+
+
+impl WebSearchResult {
+	/**
+	 * Creates a new SearchEngine result, with a corresponding result widget.
+	 */
+	pub fn new(engine: &SearchEngine, query: &str) -> Self {
+		let widget = gtk::Box::new(gtk::Orientation::Vertical, 0);
+		widget.get_style_context().add_class("Program");
+		widget.set_widget_name("SearchResult");
+		let top_button = gtk::Button::new();
+
+		{
+			top_button.get_style_context().add_class("flat");
+			widget.pack_start(&top_button, true, true, 0);
+
+			top_button.connect_clicked(move |_| {
+				// TODO: implement this
+			});
+
+			let widget_top = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+			top_button.add(&widget_top);
+
+			let icon_box = gtk::Box::new(gtk::Orientation::Vertical, 4);
+			icon_box.get_style_context().add_class("IconBox");
+			widget_top.pack_start(&icon_box, false, false, 4);
+
+			let icon = gtk::Image::from_icon_name(engine.icon.as_deref(), gtk::IconSize::Dnd);
+			icon.set_size_request(32, 32);
+			icon_box.pack_start(&icon, false, false, 0);
+
+			let description_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+			widget_top.pack_start(&description_box, true, true, 0);
+
+			let category_label = gtk::Label::new(Some(&[ "<span size='small' weight='bold'>", &engine.name, "</span>" ].join("")));
+			category_label.get_style_context().add_class("Category");
+			category_label.set_ellipsize(pango::EllipsizeMode::End);
+			category_label.set_use_markup(true);
+			category_label.set_xalign(0.0);
+			description_box.pack_start(&category_label, false, false, 1);
+
+			let label = gtk::Label::new(Some(query));
+			label.set_ellipsize(pango::EllipsizeMode::End);
+			label.set_xalign(0.0);
+			description_box.pack_start(&label, false, false, 1);
+		}
+
+		WebSearchResult {
+			engine: engine.clone(),
+			query: query.to_owned(),
+			top_button,
+			widget
+		}
+	}
+}
+
+impl SearchResult for WebSearchResult {
+	fn get_ranking(&self, query: &str) -> usize {
+		query.len() * 5 + 1
+	}
+
+	fn set_first(&self, first: bool) -> () {
+		self.top_button.set_can_focus(!first);
+	}
+
+	fn activate(&self) {
+		let mut url = Url::parse(self.engine.base_url.as_str()).unwrap();
+		url.query_pairs_mut().append_pair(self.engine.query_argument.as_str(), self.query.as_str());
+
+		match opener::open(url.as_str()) {
+			Ok(_) => {}
+			Err(e) => println!("{}", e)
+		}
+	}
+
+	fn get_result_widget(&self) -> gtk::Widget {
+		self.widget.clone().upcast()
+	}
+
+	fn get_preview_widget(&self) -> gtk::Widget {
+		let widget = gtk::Box::new(gtk::Orientation::Vertical, 4);
+		widget.get_style_context().add_class("Starter");
+		widget.set_widget_name("SearchPreview");
+		widget.set_border_width(12);
+
+		let label = gtk::Label::new(Some("Replace me"));
+		widget.pack_start(&label, false, false, 4);
+
+		widget.upcast()
+	}
+}

--- a/plugins/websearch/style/.build.css
+++ b/plugins/websearch/style/.build.css
@@ -1,0 +1,4 @@
+#SearchPreview.Starter {
+  font-size: 32px;
+  color: @c-neutral-600;
+}

--- a/plugins/websearch/style/_color.sass
+++ b/plugins/websearch/style/_color.sass
@@ -1,0 +1,20 @@
+$neutral_000: #{"@c-neutral-000"} // Border
+$neutral_100: #{"@c-neutral-100"} // Background
+$neutral_200: #{"@c-neutral-200"} // ...
+$neutral_300: #{"@c-neutral-300"} // ...
+$neutral_400: #{"@c-neutral-400"} // ...
+$neutral_500: #{"@c-neutral-500"} // ...
+$neutral_600: #{"@c-neutral-600"} // ...
+$neutral_700: #{"@c-neutral-700"} // ...
+$neutral_800: #{"@c-neutral-800"} // De-emphasized Text
+$neutral_900: #{"@c-neutral-900"} // Text
+
+
+$background-primary: #{"@c-background-primary"} // Primary background color
+$background-secondary: #{"@c-background-secondary"} // Secondary background color
+
+@function alpha($color, $alpha)
+	@return #{"alpha(" + $color + ", " + $alpha + ")"}
+
+@function mix($color_a, $color_b, $amount)
+	@return #{"mix(" + $color_a + ", " + $color_b + ", " + $amount + ")"}

--- a/plugins/websearch/style/main.sass
+++ b/plugins/websearch/style/main.sass
@@ -1,0 +1,9 @@
+@use 'color'
+
+#SearchResult.Starter
+	// Styles for your search result go here
+
+#SearchPreview.Starter
+	// Styles for your search preview go here
+	font-size: 32px
+	color: color.$c-neutral-600


### PR DESCRIPTION
I'm doing this because I want to learn rust and I'm interested in how the plugin system works. You can probably do this better, and I don't want to block you on making a better launcher: so feel free to reject this and make your own

- [x] Search result with ability to open Google
- [ ] Add support for icons
- [ ] Fix topbutton click. This requires some way for the connect_click to call `result.activate()`
- [ ] Update stylesheet to not use `starter` names
- [ ] Implement preview (?)
- [ ] Add ability to open URLs directly, when searching eg: `youtube.com`
- [ ] Add support for multiple search engines (hardcoded for now)